### PR TITLE
:bug: hotfix ignoreAtRules

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -237,3 +237,19 @@ testRule(useRem.rule, {
     },
   ],
 })
+
+// ignoreAtRules
+testRule(useRem.rule, {
+  ruleName: useRem.ruleName,
+
+  config: [true, {ignoreAtRules: ['keyframes']}],
+
+  skipBasicChecks: true,
+
+  accept: [
+    { code: '@keyframes move { from {top: 0px;} to {top: 200px;} }' }
+  ],
+
+  reject: [
+  ],
+})

--- a/index.js
+++ b/index.js
@@ -77,8 +77,10 @@ const _hasForbiddenPX = (node, options) => {
 
   /** early exit and ignore */
   if (
-    /* ignore media queries */
+    /* ignore atRules */
     (type === 'atrule' && ignoreAtRules.indexOf(node.name) !== -1) ||
+    /* ignore declarations that are children of atrules - eg: keyframes */
+    (type === 'decl' && node?.parent?.parent?.type === 'atrule' && ignoreAtRules.indexOf(node?.parent?.parent?.name) !== -1) ||
     /* ignore declarations ignored by props */
     (type === 'decl' && _propInIgnoreList(node.prop, ignore))
   ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-rem-over-px",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A stylelint rule to enforce the usage of rem units over px units.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
### Description:

- Fixes `keyframes` not being ignored even though it's passed in ignoreAtRules as `ignoreAtRules: ['keyframes']`
- closes https://github.com/a-tokyo/stylelint-rem-over-px/issues/2