### PR TITLE
ci: migrate release pipeline to npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -1,29 +1,40 @@
 name: Test Release Publish
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: write
+  id-token: write
 
 jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x, 24.x]
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get yarn cache
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ubuntu-latest-node-18.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ubuntu-latest-node-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ubuntu-latest-node-18.x-yarn-
-      - uses: actions/setup-node@v3
+            ubuntu-latest-node-${{ matrix.node-version }}-yarn-
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/
       - name: Install
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Test
         run: yarn test
 
@@ -32,40 +43,53 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: success() && github.ref == 'refs/heads/main'
+    environment: production
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Get yarn cache
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ubuntu-latest-node-18.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ubuntu-latest-node-24.x-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ubuntu-latest-node-18.x-yarn-
-      - uses: actions/setup-node@v3
+            ubuntu-latest-node-24.x-yarn-
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24.x
           registry-url: https://registry.npmjs.org/
       - name: Install
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Setup env vars
         id: ownEnvVars
         run: |
           # Set PACKAGE_VERSION
           PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
-          echo ::set-output name=PACKAGE_VERSION::$PACKAGE_VERSION
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
           # Set COMMIT_LOG
-          COMMIT_LOG=`git log $(git describe --tags --abbrev=0)..HEAD --format='%s - %an'`
-          echo ::set-output name=COMMIT_LOG::$COMMIT_LOG
+          {
+            echo "COMMIT_LOG<<EOF"
+            git log $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD --format='- %s (%an)'
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+      - name: Check if version already released
+        id: check_tag
+        run: |
+          if git rev-parse "refs/tags/${{ env.PACKAGE_VERSION }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: ncipollo/release-action@v1
+        if: steps.check_tag.outputs.exists == 'false'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.ownEnvVars.outputs.PACKAGE_VERSION }}
+          tag: ${{ env.PACKAGE_VERSION }}
           commit: main
-          body: ${{ steps.ownEnvVars.outputs.COMMIT_LOG }}
+          body: ${{ env.COMMIT_LOG }}
       - name: npm publish
+        if: steps.check_tag.outputs.exists == 'false'
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Migrate the GitHub release pipeline to the "new way" used in `apple-signin-auth` / `react-apple-signin-auth`.

- Add a `pull_request` trigger and top-level `permissions` (`contents: write`, `id-token: write`).
- Extend the test matrix to **20.x / 22.x / 24.x**; release on 24.x.
- Publish via **npm OIDC trusted publishing**: removed the `NPM_TOKEN` secret, added `environment: production`.
- Added a **tag-exists guard** (skips release/publish when the version tag already exists), `fetch-depth: 0`, and a first-release-safe changelog.
- No build step (pure ESM); `codeql.yml` left untouched.

## Note

Publishing only succeeds once the npm **trusted publisher** is configured for `stylelint-rem-over-px` (org/repo `a-tokyo/stylelint-rem-over-px`, workflow file `test-publish.yml`, environment `production`) — handled in a separate npm-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
